### PR TITLE
Fix stream.address upon onConnect

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ exports.init = function (sbot, config) {
           })
 
           handlers[instance] = function (stream) {
-            stream.address = 'tunnel:'+portal
+            stream.address = 'tunnel:'+portal+':'+sbot.id
             onConnect(stream)
           }
           //close server


### PR DESCRIPTION
I still haven't gotten ssb-tunnel working in a proof of concept I'm trying out, so **I am not sure if this pull request is correct**, but it seems to me that theoretically all the tunnel addresses should be of the format `tunnel:{portal}:{target}` and in this specific case it was `tunnel:{portal}`.