### PR TITLE
address shows the client id

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,8 +124,8 @@ exports.init = function (sbot, config) {
             })
           })
 
-          handlers[instance] = function (stream) {
-            stream.address = 'tunnel:'+portal
+          handlers[instance] = function (stream, id) {
+            stream.address = 'tunnel:'+portal+':'+id
             onConnect(stream)
           }
           //close server
@@ -173,7 +173,7 @@ exports.init = function (sbot, config) {
       //if this connection is for us
       else if(opts.target === sbot.id && handlers[opts.port]) {
         var streams = DuplexPair()
-        handlers[opts.port](streams[0])
+        handlers[opts.port](streams[0], this.id)
         return streams[1]
       }
       else


### PR DESCRIPTION
@staltz I think this would be a more correct version of https://github.com/ssbc/ssb-tunnel/pull/4

the address of a server stream should _identify the client_
by analogy a net server (the prototypical server) has a remoteAddress and remotePort
which is combined into the address.
https://github.com/ssbc/multiserver/blob/master/plugins/net.js#L20
unlike addresses given out by `sbot.getAddress(scope)` the address on the stream probably won't be connectable. on a net stream, it will have a port, but the port on the client won't be a server. it will just be something random. still it contains the information known about the client, their apparent ip address. (probably not NAT address, not their computer, though) so showing the portal they are connecting through and their id makes sense. They may not have announced at that portal though so doesn't mean you can connect to that address. if you wanted to connect you have them give your their address somehow, such as calling `rpc.getAddress('public')` (which isn't exposed by default) or some other lookup or gossip etc...

